### PR TITLE
Update index.js

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -60,7 +60,8 @@ var onSocketMsg = {
 
 var newConnection = function() {
 	sock = new SockJS(url.format({
-		protocol: urlParts.protocol,
+		//fixed: If hostname is 0.0.0.0 it correctly replaces it with window.location.hostname but forgets to replace urlParts.protocol
+		protocol: window.location.protocol == "https:" ?  "https:" : urlParts.protocol,
 		auth: urlParts.auth,
 		hostname: (urlParts.hostname === '0.0.0.0') ? window.location.hostname : urlParts.hostname,
 		port: (urlParts.port == '0') ? window.location.port : urlParts.port,


### PR DESCRIPTION
If hostname is 0.0.0.0 it correctly replaces it with window.location.hostname but forgets to replace urlParts.protocol
Fixed per https://community.c9.io/t/mixed-content-with-webpack-dev-server/3053

This now allows me to do hot updating of web page from cloud 9.
